### PR TITLE
Refactor/tokens repository improvement

### DIFF
--- a/Sources/SolanaSwift/Helpers/Cache/Cache.swift
+++ b/Sources/SolanaSwift/Helpers/Cache/Cache.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class Cache<Key: Hashable, Value> {
+final actor Cache<Key: Hashable, Value> {
     private let wrapped = NSCache<WrappedKey, Entry>()
 
     func insert(_ value: Value, forKey key: Key) {

--- a/Sources/SolanaSwift/TokensRepository/SolanaTokensRepository.swift
+++ b/Sources/SolanaSwift/TokensRepository/SolanaTokensRepository.swift
@@ -1,0 +1,9 @@
+public protocol SolanaTokensRepository {
+    func getTokensList(useCache: Bool) async throws -> Set<Token>
+}
+
+extension SolanaTokensRepository {
+    func getTokensList() async throws -> Set<Token> {
+        try await getTokensList(useCache: true)
+    }
+}

--- a/Sources/SolanaSwift/TokensRepository/TokensListParser.swift
+++ b/Sources/SolanaSwift/TokensRepository/TokensListParser.swift
@@ -21,43 +21,56 @@ public class TokensListParser {
     public func parse(network: String) async throws -> Set<Token> {
         guard let url = tokenListURL else { throw TokensListParserError.invalidTokenlistURL }
         let urlRequest = URLRequest(url: url)
+        
+        // check for cancellation
+        try Task.checkCancellation()
+        
+        // get data
         let data = try await networkManager.requestData(request: urlRequest)
-        let tokenList: TokensList
-        do {
-            tokenList = try JSONDecoder().decode(TokensList.self, from: data)
-        } catch {
-            // get json file
-            let bundle = Bundle(for: TokensListParser.self)
-            let path = bundle.path(forResource: network + ".tokens", ofType: "json")
-            let jsonData = try Data(contentsOf: URL(fileURLWithPath: path ?! TokensListParserError.invalidTokenlistPath))
-            tokenList = try JSONDecoder().decode(TokensList.self, from: jsonData)
-        }
-
-        // map tags
-        var tokens: [Token] = tokenList.tokens.map {
-            var item = $0
-            item.tags = (item._tags ?? []).map {
-                tokenList.tags[$0] ?? TokenTag(name: $0, description: $0)
+        
+        // check again for cancellation
+        try Task.checkCancellation()
+        
+        // decode data in other thread because it's a very big list with a lot of tokens
+        return try await Task {
+            let tokenList: TokensList
+            do {
+                tokenList = try JSONDecoder().decode(TokensList.self, from: data)
+            } catch {
+                // get json file
+                let bundle = Bundle(for: TokensListParser.self)
+                let path = bundle.path(forResource: network + ".tokens", ofType: "json")
+                let jsonData = try Data(contentsOf: URL(fileURLWithPath: path ?! TokensListParserError.invalidTokenlistPath))
+                tokenList = try JSONDecoder().decode(TokensList.self, from: jsonData)
             }
-            return item
-        }
 
-        // TODO: Move outside parser
-        // renBTC for devnet
-        if network == "devnet" {
-            tokens.append(
-                .init(
-                    _tags: nil,
-                    chainId: 101,
-                    address: "FsaLodPu4VmSwXGr3gWfwANe4vKf8XSZcCh1CEeJ3jpD",
-                    symbol: "renBTC",
-                    name: "renBTC",
-                    decimals: 8,
-                    logoURI: "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CDJWUqTcYTVAKXAVXoQZFes5JUFc7owSeq7eMQcDSbo5/logo.png",
-                    extensions: .init(website: "https://renproject.io/", bridgeContract: nil, assetContract: nil, address: nil, explorer: nil, twitter: nil, github: nil, medium: nil, tgann: nil, tggroup: nil, discord: nil, serumV3Usdt: nil, serumV3Usdc: "74Ciu5yRzhe8TFTHvQuEVbFZJrbnCMRoohBK33NNiPtv", coingeckoId: "renbtc", imageUrl: nil, description: nil)
+            // map tags
+            var tokens: [Token] = tokenList.tokens.map {
+                var item = $0
+                item.tags = (item._tags ?? []).map {
+                    tokenList.tags[$0] ?? TokenTag(name: $0, description: $0)
+                }
+                return item
+            }
+
+            // TODO: Move outside parser
+            // renBTC for devnet
+            if network == "devnet" {
+                tokens.append(
+                    .init(
+                        _tags: nil,
+                        chainId: 101,
+                        address: "FsaLodPu4VmSwXGr3gWfwANe4vKf8XSZcCh1CEeJ3jpD",
+                        symbol: "renBTC",
+                        name: "renBTC",
+                        decimals: 8,
+                        logoURI: "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CDJWUqTcYTVAKXAVXoQZFes5JUFc7owSeq7eMQcDSbo5/logo.png",
+                        extensions: .init(website: "https://renproject.io/", bridgeContract: nil, assetContract: nil, address: nil, explorer: nil, twitter: nil, github: nil, medium: nil, tgann: nil, tggroup: nil, discord: nil, serumV3Usdt: nil, serumV3Usdc: "74Ciu5yRzhe8TFTHvQuEVbFZJrbnCMRoohBK33NNiPtv", coingeckoId: "renbtc", imageUrl: nil, description: nil)
+                    )
                 )
-            )
+            }
+            return Set(tokens)
         }
-        return Set(tokens)
+            .value
     }
 }

--- a/Sources/SolanaSwift/TokensRepository/TokensRepository.swift
+++ b/Sources/SolanaSwift/TokensRepository/TokensRepository.swift
@@ -1,15 +1,5 @@
 import Foundation
 
-public protocol SolanaTokensRepository {
-    func getTokensList(useCache: Bool) async throws -> Set<Token>
-}
-
-extension SolanaTokensRepository {
-    func getTokensList() async throws -> Set<Token> {
-        try await getTokensList(useCache: true)
-    }
-}
-
 public class TokensRepository: SolanaTokensRepository {
 
     // MARK: - Properties

--- a/Sources/SolanaSwift/TokensRepository/TokensRepository.swift
+++ b/Sources/SolanaSwift/TokensRepository/TokensRepository.swift
@@ -1,20 +1,27 @@
 import Foundation
 
-public class TokensRepository {
+public protocol SolanaTokensRepository {
+    func getTokensList(useCache: Bool) async throws -> Set<Token>
+}
 
-    // MARK: -
-    
-    public init(apiClient: SolanaAPIClient, tokenListParser: TokensListParser = .init()) {
-        self.apiClient = apiClient
-        self.tokenListParser = tokenListParser
+extension SolanaTokensRepository {
+    func getTokensList() async throws -> Set<Token> {
+        try await getTokensList(useCache: true)
     }
+}
 
-    private let tokenListParser: TokensListParser
-    private let apiClient: SolanaAPIClient
+public class TokensRepository: SolanaTokensRepository {
+
+    // MARK: - Properties
     private static var tokenCache = Cache<String, Set<Token>>()
     private let tokenCacheKey = "TokenRepositoryTokensKey"
-    private var endpoint: APIEndPoint {
-        apiClient.endpoint
+    
+    private let tokenListParser: TokensListParser
+    private let endpoint: APIEndPoint
+    
+    public init(endpoint: APIEndPoint, tokenListParser: TokensListParser = .init()) {
+        self.endpoint = endpoint
+        self.tokenListParser = tokenListParser
     }
     
     // MARK: - Public Methods
@@ -33,73 +40,4 @@ public class TokensRepository {
         await TokensRepository.tokenCache.insert(tokenlist, forKey: tokenCacheKey)
         return tokenlist
     }
-    
-    /// Method retrieves token wallets
-    /// - Parameters:
-    ///  - account: Public key of an account
-    /// - Throws: TokenRepositoryError
-    /// - Returns array of Wallet
-    ///
-    public func getTokenWallets(account: String) async throws -> [Wallet] {
-        async let accounts = try await apiClient.getTokenAccountsByOwner(pubkey: account,
-                                                                         params: .init(mint: nil, programId: TokenProgram.id.base58EncodedString),
-                                                               configs: .init(encoding: "base64"))
-        async let tokens = try await getTokensList()
-        var knownWallets = [Wallet]()
-        var unknownAccounts = [(String, AccountInfo)]()
-        
-        let (list, supportedTokens) = (try await accounts, try await tokens)
-
-        for item in list {
-            let pubkey = item.pubkey
-            let accountInfo = item.account.data
-
-            let mintAddress = accountInfo.mint.base58EncodedString
-            // known token
-            if let token = supportedTokens.first(where: {$0.address == mintAddress}) {
-                knownWallets.append(
-                    Wallet(
-                        pubkey: pubkey,
-                        lamports: accountInfo.lamports,
-                        token: token
-                    )
-                )
-            } else {
-                // unknown token
-                unknownAccounts.append((item.pubkey, item.account.data))
-            }
-        }
-        let mintDatas = try await apiClient.getMultipleMintDatas(mintAddresses: unknownAccounts.map{ $0.1.mint.base58EncodedString })
-        guard mintDatas.count == unknownAccounts.count else { throw SolanaError.unknown }
-        let wallets = mintDatas.enumerated().map {
-            Wallet(
-                pubkey: unknownAccounts[$0].0,
-                lamports: unknownAccounts[$0].1.lamports,
-                token: .unsupported(
-                    mint: unknownAccounts[$0].1.mint.base58EncodedString,
-                    decimals: $1.value.decimals
-                )
-            )
-        }
-        return knownWallets + wallets
-    }
-    
-    /// Method checks account validation
-    /// - Parameters:
-    ///  - account: Public key of an account
-    /// - Throws: TokenRepositoryError
-    /// - Returns wether account is valid
-    ///
-    public func checkAccountValidation(account: String) async throws -> Bool {
-        do {
-            _ = try await apiClient.getAccountInfo(account: account) as BufferInfo<EmptyInfo>?
-        } catch let error as SolanaError where error == .couldNotRetrieveAccountInfo {
-            return false
-        } catch let error {
-            throw error
-        }
-        return true
-    }
-
-    // MARK: -
 }

--- a/Tests/SolanaSwiftTests/APIClient/APIClientExtensionsTests.swift
+++ b/Tests/SolanaSwiftTests/APIClient/APIClientExtensionsTests.swift
@@ -38,4 +38,23 @@ class APIClientExtensionsTests: XCTestCase {
     func testCheckIfAssociatedTokenAccountExists() async throws {
         // TODO:
     }
+    
+//    func testGetTokenWallets() async throws {
+//        let mock = MockNetworkManager(withError: false)
+//        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+//        let datas = try! await tokenRepository.getTokenWallets(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
+//        XCTAssertNotEqual(datas.count, 0)
+//    }
+//
+//    func testCheckAccountValidation() async throws {
+//        let mock = MockNetworkManager(withError: false)
+//        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+//        // funding SOL address
+//        let isValid1 = try await tokenRepository.checkAccountValidation(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
+//        XCTAssertEqual(isValid1, true)
+//
+//        // no funding SOL address
+//        let isValid2 = try await tokenRepository.checkAccountValidation(account: "HnXJX1Bvps8piQwDYEYC6oea9GEkvQvahvRj3c97X9xr")
+//        XCTAssertEqual(isValid2, false)
+//    }
 }

--- a/Tests/SolanaSwiftTests/TokensRepository/TokensRepositoryTests.swift
+++ b/Tests/SolanaSwiftTests/TokensRepository/TokensRepositoryTests.swift
@@ -3,18 +3,11 @@ import XCTest
 
 class TokensRepositoryTests: XCTestCase {
     
-    let endpoint = APIEndPoint(
-        address: "https://api.mainnet-beta.solana.com",
-        network: .mainnetBeta
-    )
-
-    override func setUpWithError() throws {}
-
-    override func tearDownWithError() throws {}
+    let apiClient = JSONRPCAPIClient(endpoint: .defaultEndpoints.first!)
     
     func testTokenRepository() async throws {
         let mock = MockNetworkManager()
-        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
         let list = try await tokenRepository.getTokensList()
         XCTAssertFalse(list.isEmpty)
         XCTAssertEqual(list.count, 1)
@@ -28,12 +21,12 @@ class TokensRepositoryTests: XCTestCase {
         // Putting to cache
         try? await {
             let mock = MockNetworkManager()
-            let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+            let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
             _ = try await tokenRepository.getTokensList()
         }()
         
         let mock = MockNetworkManager(withError: true)
-        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
         let list = try await tokenRepository.getTokensList()
         XCTAssertFalse(list.isEmpty)
         XCTAssertEqual(list.count, 1)
@@ -41,7 +34,7 @@ class TokensRepositoryTests: XCTestCase {
     
     func testTokenRepositoryNoCacheNetworkError() async throws {
         let mock = MockNetworkManager(withError: true)
-        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
         do {
             let list = try await tokenRepository.getTokensList(useCache: false)
             XCTAssertTrue(list.isEmpty)
@@ -52,14 +45,14 @@ class TokensRepositoryTests: XCTestCase {
     
     func testGetTokenWallets() async throws {
         let mock = MockNetworkManager(withError: false)
-        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
         let datas = try! await tokenRepository.getTokenWallets(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
         XCTAssertNotEqual(datas.count, 0)
     }
 
     func testCheckAccountValidation() async throws {
         let mock = MockNetworkManager(withError: false)
-        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
         // funding SOL address
         let isValid1 = try await tokenRepository.checkAccountValidation(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
         XCTAssertEqual(isValid1, true)

--- a/Tests/SolanaSwiftTests/TokensRepository/TokensRepositoryTests.swift
+++ b/Tests/SolanaSwiftTests/TokensRepository/TokensRepositoryTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 class TokensRepositoryTests: XCTestCase {
     
-    let apiClient = JSONRPCAPIClient(endpoint: .defaultEndpoints.first!)
+    let endpoint: APIEndPoint = .defaultEndpoints.first!
     
     func testTokenRepository() async throws {
         let mock = MockNetworkManager()
-        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
         let list = try await tokenRepository.getTokensList()
         XCTAssertFalse(list.isEmpty)
         XCTAssertEqual(list.count, 1)
@@ -21,12 +21,12 @@ class TokensRepositoryTests: XCTestCase {
         // Putting to cache
         try? await {
             let mock = MockNetworkManager()
-            let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
+            let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
             _ = try await tokenRepository.getTokensList()
         }()
         
         let mock = MockNetworkManager(withError: true)
-        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
         let list = try await tokenRepository.getTokensList()
         XCTAssertFalse(list.isEmpty)
         XCTAssertEqual(list.count, 1)
@@ -34,32 +34,13 @@ class TokensRepositoryTests: XCTestCase {
     
     func testTokenRepositoryNoCacheNetworkError() async throws {
         let mock = MockNetworkManager(withError: true)
-        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
+        let tokenRepository = TokensRepository(endpoint: endpoint, tokenListParser: TokensListParser(networkManager: mock))
         do {
             let list = try await tokenRepository.getTokensList(useCache: false)
             XCTAssertTrue(list.isEmpty)
         } catch {
             XCTAssertTrue(true)
         }
-    }
-    
-    func testGetTokenWallets() async throws {
-        let mock = MockNetworkManager(withError: false)
-        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
-        let datas = try! await tokenRepository.getTokenWallets(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
-        XCTAssertNotEqual(datas.count, 0)
-    }
-
-    func testCheckAccountValidation() async throws {
-        let mock = MockNetworkManager(withError: false)
-        let tokenRepository = TokensRepository(apiClient: apiClient, tokenListParser: TokensListParser(networkManager: mock))
-        // funding SOL address
-        let isValid1 = try await tokenRepository.checkAccountValidation(account: "3h1zGmCwsRJnVk5BuRNMLsPaQu1y2aqXqXDWYCgrp5UG")
-        XCTAssertEqual(isValid1, true)
-
-        // no funding SOL address
-        let isValid2 = try await tokenRepository.checkAccountValidation(account: "HnXJX1Bvps8piQwDYEYC6oea9GEkvQvahvRj3c97X9xr")
-        XCTAssertEqual(isValid2, false)
     }
 
     class MockNetworkManager: NetworkManager {


### PR DESCRIPTION
## Problems
- `TokensRepository` can not be an `actor`, because in `actor`, there will be only 1 function to be called at a time and there is no risk of data race in `TokensRepository`, so `actor` is not needed .
- The best candidate for an `actor` is `Cache`. It guarantees that data in `Cache` can be written serially and prevents data race.
- Method `getTokensWallet` and `checkAccountValidation` must be declared in APIClient extension, because its related to data in blockchain, `TokensRepository` has only 1 aim: get list of supported tokens from solana's github repository.
- The decoding in `TokensListParser` needs to be done in another thread, because the list is very big.
## Solution
- Add `SolanaTokensRepository` protocol to abstract it.
- Change `TokensRepository` to `class` instead of `actor`.
- Change `Cache` from `class` to `actor`.
- Move methods that related to `apiClient` to `APIClient+Extensions.swift `
- Add separate `Task` in decoding data after network request.