### PR TITLE
fix: `Message` deserialization

### DIFF
--- a/Sources/SolanaSwift/Extensions/Data+Extensions.swift
+++ b/Sources/SolanaSwift/Extensions/Data+Extensions.swift
@@ -9,34 +9,34 @@ import Foundation
 
 public extension Data {
     var decodedLength: Int {
-        var len = 0
-        var size = 0
+        var len: UInt8 = 0
+        var size: UInt8 = 0
         var bytes = self
         while true {
             guard let elem = bytes.first else { break }
             bytes = bytes.dropFirst()
-            len = len | ((Int(elem) & 0x7F) << (size * 7))
+            len |= (elem & 0x7F) << (size * 7)
             size += 1
-            if Int16(elem) & 0x80 == 0 {
+            if elem & 0x80 == 0 {
                 break
             }
         }
-        return len
+        return Int(len)
     }
 
-    mutating func decodeLength() throws -> Int {
-        var len = 0
-        var size = 0
+    mutating func decodeLength() -> Int {
+        var len: UInt8 = 0
+        var size: UInt8 = 0
         while true {
             guard let elem = bytes.first else { break }
             _ = popFirst()
-            len = len | ((Int(elem) & 0x7F) << (size * 7))
+            len |= (elem & 0x7F) << (size * 7)
             size += 1
-            if Int16(elem) & 0x80 == 0 {
+            if elem & 0x80 == 0 {
                 break
             }
         }
-        return len
+        return Int(len)
     }
 
     static func encodeLength(_ len: Int) -> Data {

--- a/Sources/SolanaSwift/Models/SendingTransaction/Message.swift
+++ b/Sources/SolanaSwift/Models/SendingTransaction/Message.swift
@@ -61,33 +61,31 @@ public extension Transaction {
         static func from(data: Data) throws -> Message {
             var data = data
 
-            let numRequiredSignatures = data.popFirst()!
-            let numReadonlySignedAccounts = data.popFirst()!
-            let numReadonlyUnsignedAccounts = data.popFirst()!
+            let numRequiredSignatures = data.removeFirst()
+            let numReadonlySignedAccounts = data.removeFirst()
+            let numReadonlyUnsignedAccounts = data.removeFirst()
 
             let accountCount = data.decodeLength()
             var accountKeys: [PublicKey] = []
-            for _ in stride(from: 0, through: accountCount - 1, by: 1) {
+            for _ in 0..<accountCount {
                 let account = data.prefix(PublicKey.numberOfBytes)
                 data = data.dropFirst(PublicKey.numberOfBytes)
                 accountKeys.append(try PublicKey(string: Base58.encode(account.bytes)))
             }
 
             let recentBlockhash = data.prefix(PublicKey.numberOfBytes)
-            print(Base58.encode(recentBlockhash.bytes))
             data = data.dropFirst(PublicKey.numberOfBytes)
 
             let instructionCount = data.decodeLength()
-            print(instructionCount)
             var instructions: [CompiledInstruction] = []
-            for _ in stride(from: 0, through: instructionCount - 1, by: 1) {
-                let programIdIndex = data.popFirst()!
+            for _ in 0..<instructionCount {
+                let programIdIndex = data.removeFirst()
                 let accountCount = data.decodeLength()
                 let accounts = data.prefix(accountCount)
                 data = data.dropFirst(accountCount)
                 let dataLength = data.decodeLength()
                 let dataSlice = data.prefix(dataLength)
-                data = data.suffix(dataLength)
+                data = data.dropFirst(dataLength)
                 instructions.append(
                     CompiledInstruction(
                         programIdIndex: programIdIndex,
@@ -157,7 +155,7 @@ public extension Transaction {
 public extension Transaction.Message {
     // MARK: - Nested type
 
-    struct Header: Decodable {
+    struct Header: Decodable, Equatable {
         static let LENGTH = 3
 
         var numRequiredSignatures: Int = 0

--- a/Sources/SolanaSwift/Models/SendingTransaction/Message.swift
+++ b/Sources/SolanaSwift/Models/SendingTransaction/Message.swift
@@ -65,7 +65,7 @@ public extension Transaction {
             let numReadonlySignedAccounts = data.popFirst()!
             let numReadonlyUnsignedAccounts = data.popFirst()!
 
-            let accountCount = try data.decodeLength()
+            let accountCount = data.decodeLength()
             var accountKeys: [PublicKey] = []
             for _ in stride(from: 0, through: accountCount - 1, by: 1) {
                 let account = data.prefix(PublicKey.numberOfBytes)
@@ -77,15 +77,15 @@ public extension Transaction {
             print(Base58.encode(recentBlockhash.bytes))
             data = data.dropFirst(PublicKey.numberOfBytes)
 
-            let instructionCount = try data.decodeLength()
+            let instructionCount = data.decodeLength()
             print(instructionCount)
             var instructions: [CompiledInstruction] = []
             for _ in stride(from: 0, through: instructionCount - 1, by: 1) {
                 let programIdIndex = data.popFirst()!
-                let accountCount = try data.decodeLength()
+                let accountCount = data.decodeLength()
                 let accounts = data.prefix(accountCount)
                 data = data.dropFirst(accountCount)
-                let dataLength = try data.decodeLength()
+                let dataLength = data.decodeLength()
                 let dataSlice = data.prefix(dataLength)
                 data = data.suffix(dataLength)
                 instructions.append(

--- a/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
+++ b/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
@@ -335,7 +335,7 @@ public struct Transaction: Encodable {
     public static func from(data: Data) throws -> Transaction {
         var data = data
         var signatures: [String] = []
-        let signatureCount = try data.decodeLength()
+        let signatureCount = data.decodeLength()
 
         for _ in stride(from: 0, through: signatureCount - 1, by: 1) {
             let signatureData = data.prefix(Transaction.SIGNATURE_LENGTH)

--- a/Tests/SolanaSwiftUnitTests/Models/SendingTransaction/MessageTests.swift
+++ b/Tests/SolanaSwiftUnitTests/Models/SendingTransaction/MessageTests.swift
@@ -1,0 +1,36 @@
+//
+//  MessageTests.swift
+//  
+//
+//  Created by Kamil Wyszomerski on 20/06/2022.
+//
+
+import XCTest
+@testable import SolanaSwift
+
+class MessageTests: XCTestCase {
+
+    func test_givenRawMessage_whenFrom_thenReturnsExpectedMessage() throws {
+
+        // given
+        let expectedMessge = Transaction.Message.StubFactory.makeSignedWithInstructions()
+        // Base64-encoded message containing two instructions some accounts and signers.
+        let base64 = "AgADBSxW7AhRsOx/s4ecSWrcic9vfD5asiW3d287f4uUsKeb7oz2DHCBpIZPzhc3kCRgNxVedAceB6yMl6hi5hPA1OkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFxRIYzJTD1K8X9Y2u4Im6H9ROPb2YoAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkHQqjYoL28uYrjQx7GX6lt1z+mBGwH0eqdU9JknzvwfQICAgABNAAAAADwHR8AAAAAAKUAAAAAAAAABt324ddloZPZy+FGzut5rBy0he1fWzeROoz1hX7/AKkEAgADQwAALFbsCFGw7H+zh5xJatyJz298PlqyJbd3bzt/i5Swp5sAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        let rawMessage = try XCTUnwrap(Data(base64Encoded: base64))
+
+        // when
+        let result = try Transaction.Message.from(data: rawMessage)
+
+        // then
+        XCTAssertEqual(result.header, expectedMessge.header)
+        XCTAssertEqual(result.recentBlockhash, expectedMessge.recentBlockhash)
+        XCTAssertEqual(result.accountKeys, expectedMessge.accountKeys)
+        zip(result.instructions, expectedMessge.instructions).forEach {
+            XCTAssertEqual($0.accounts, $1.accounts)
+            XCTAssertEqual($0.data, $1.data)
+            XCTAssertEqual($0.dataLength, $1.dataLength)
+            XCTAssertEqual($0.keyIndicesCount, $1.keyIndicesCount)
+            XCTAssertEqual($0.serializedData, $1.serializedData)
+        }
+    }
+}

--- a/Tests/SolanaSwiftUnitTests/Other/CodableTests/EncodingTests.swift
+++ b/Tests/SolanaSwiftUnitTests/Other/CodableTests/EncodingTests.swift
@@ -10,12 +10,7 @@ import SolanaSwift
 import XCTest
 
 class EncodingTests: XCTestCase {
-    func testCodingBytesLength() throws {
-        let bytes = Data([5, 3, 1, 2, 3, 7, 8, 5, 4])
-        XCTAssertEqual(bytes.decodedLength, 5)
-        let bytes2 = Data([74, 174, 189, 206, 113, 78, 60, 226, 136, 170])
-        XCTAssertEqual(bytes2.decodedLength, 74)
-
+    func testEncodingBytesLength() throws {
         XCTAssertEqual(Data([0]), Data.encodeLength(0))
         XCTAssertEqual(Data([1]), Data.encodeLength(1))
         XCTAssertEqual(Data([5]), Data.encodeLength(5))
@@ -25,5 +20,57 @@ class EncodingTests: XCTestCase {
         XCTAssertEqual(Data([0x80, 0x02]), Data.encodeLength(256))
         XCTAssertEqual(Data([0xFF, 0xFF, 0x01]), Data.encodeLength(32767))
         XCTAssertEqual(Data([0x80, 0x80, 0x80, 0x01]), Data.encodeLength(2_097_152))
+    }
+
+    func test_givenBytes_whenDecodeLength_thenReturnsExpectedLength() throws {
+
+        // given
+        var bytes = Data([5, 3, 1, 2, 3, 7, 8, 5, 4])
+
+        // when
+        let result = bytes.decodeLength()
+
+        // then
+        XCTAssertEqual(result, 5)
+    }
+
+    func test_givenBytes_whenDecodeLengthTwice_thenReturnsExpectedLengths() throws {
+
+        // given
+        var bytes = Data([5, 0xf3, 1, 2, 3, 7, 8, 5, 4])
+
+        // when
+        let result1 = bytes.decodeLength()
+        let result2 = bytes.decodeLength()
+
+        // then
+        XCTAssertEqual(result1, 5)
+        XCTAssertEqual(result2, 0xf3)
+    }
+
+    func test_givenBytes_whenDecodeLength_thenRemovesFirstByte() throws {
+
+        // given
+        var bytes = Data([5, 1, 2, 3, 7, 8, 3, 4])
+        let numberOfBytes = bytes.count
+
+        // when
+        _ = bytes.decodeLength()
+
+        // then
+        XCTAssertFalse(bytes.contains(5))
+        XCTAssertEqual(bytes.count, numberOfBytes - 1)
+    }
+
+    func test_givenZeroBytes_whenDecodeLength_thenReturnsZero() throws {
+
+        // given
+        var bytes = Data()
+
+        // when
+        let result = bytes.decodeLength()
+
+        // then
+        XCTAssertEqual(result, 0)
     }
 }

--- a/Tests/SolanaSwiftUnitTests/TestDoubles/MessageStub.swift
+++ b/Tests/SolanaSwiftUnitTests/TestDoubles/MessageStub.swift
@@ -1,0 +1,49 @@
+//
+//  MessageStub.swift
+//  
+//
+//  Created by Kamil Wyszomerski on 20/06/2022.
+//
+
+import Foundation
+@testable import SolanaSwift
+
+extension Transaction.Message {
+
+    enum StubFactory {
+
+        static func makeSignedWithInstructions() -> Transaction.Message {
+            .init(
+                header: .init(
+                    numRequiredSignatures: 2,
+                    numReadonlySignedAccounts: 0,
+                    numReadonlyUnsignedAccounts: 3
+                ),
+                accountKeys: [
+                    try! PublicKey(string: "3z5p9oNxJVDkxkcvxkb9bcYZJsipNseRKzLC9N9CPZD4"),
+                    try! PublicKey(string: "H4ChXmobu28k7SLHfybPt3w2CHaxiXZ4hn6rmDcTxsyS"),
+                    try! PublicKey(string: "11111111111111111111111111111111"),
+                    try! PublicKey(string: "SysvarRent111111111111111111111111111111111"),
+                    try! PublicKey(string: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+                ],
+                recentBlockhash: "VLortStdEx517K8wQ4eaijZGzrYVxenfoDYKGhkeGYc",
+                instructions: [
+                    .init(
+                        programIdIndex: 2,
+                        keyIndicesCount: [2],
+                        keyIndices: [0, 1],
+                        dataLength: [52],
+                        data: Base58.decode("11119os1e9qSs2u7TsThXqkBSRVFxhmYaFKFZ1waB2X7armDmvK3p5GmLdUxYdg3h7QSrL")
+                    ),
+                    .init(
+                        programIdIndex: 4,
+                        keyIndicesCount: [2],
+                        keyIndices: [0, 3],
+                        dataLength: [67],
+                        data: Base58.decode("114uwbVTPRz2R47GYXvCB1asLS15keuV56qsVWt112YpzPp2osYuGtdJ9wenk2w7hT6pnZA2FDcT65SV7nbuk11kXUs")
+                    )
+                ]
+            )
+        }
+    }
+}


### PR DESCRIPTION
This PR contains fixes for `Message.from` method and tests which proves the fix. 
Same Base64 raw message was used and output was compared with https://github.com/solana-labs/solana-web3.js .