### PR TITLE
feat: public partial sign

### DIFF
--- a/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
+++ b/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
@@ -93,6 +93,24 @@ public struct Transaction: Encodable {
 
     // MARK: - Signing
 
+    public mutating func partialSign(signers: [Account]) throws {
+        guard !signers.isEmpty else { throw SolanaError.invalidRequest(reason: "No signers") }
+
+        // unique signers
+        let signers = signers.reduce([Account]()) { signers, signer in
+            var uniqueSigners = signers
+            if !uniqueSigners.contains(where: { $0.publicKey == signer.publicKey }) {
+                uniqueSigners.append(signer)
+            }
+            return uniqueSigners
+        }
+
+        // construct message
+        let message = try compile()
+
+        try partialSign(message: message, signers: signers)
+    }
+
     private mutating func partialSign(message: Message, signers: [Account]) throws {
         let signData = try message.serialize()
 

--- a/Tests/SolanaSwiftUnitTests/Models/SendingTransaction/TransactionTests.swift
+++ b/Tests/SolanaSwiftUnitTests/Models/SendingTransaction/TransactionTests.swift
@@ -1,0 +1,92 @@
+//
+//  TransactionTests.swift
+//  
+//
+//  Created by Kamil Wyszomierski on 21/06/2022.
+//
+
+import SolanaSwift
+import XCTest
+
+class TransactionTests: XCTestCase {
+
+    func test_givenSigner_whenPartialSign_thenSignerAppended() throws {
+
+        // given
+        let signer = Account.StubFactory.make()
+        var transaction = Self.makeTransaction(signer: signer)
+
+        // when
+        try transaction.partialSign(signers: [signer])
+
+        // then
+        XCTAssertTrue(transaction.signatures.contains(where: { $0.publicKey == signer.publicKey }))
+    }
+
+    func test_givenSignerAndInvalidTransaction_whenPartialSign_thenThrowsError() throws {
+
+        // given
+        let signer = Account.StubFactory.make()
+        var transaction = Transaction(
+            instructions: [],
+            recentBlockhash: "",
+            feePayer: .StubFactory.make()
+        )
+
+        // when
+        // then
+        XCTAssertThrowsError(try transaction.partialSign(signers: [signer]))
+    }
+
+    func test_givenPartiallySignedTransactionAndSameSigner_whenPartialSign_thenSignerNotAdded() throws {
+
+        // given
+        let signer = Account.StubFactory.make()
+        var transaction = Self.makeTransaction(signer: signer)
+        try transaction.partialSign(signers: [signer])
+        let numberOfSignatures = transaction.signatures.count
+
+        // when
+        try transaction.partialSign(signers: [signer])
+
+        // then
+        XCTAssertEqual(numberOfSignatures, transaction.signatures.count)
+    }
+
+    func test_givenEmptySigners_whenPartialSign_thenThrowsError() throws {
+
+        // given
+        let signer = Account.StubFactory.make()
+        var transaction = Self.makeTransaction(signer: signer)
+
+        // when
+        // then
+        XCTAssertThrowsError(try transaction.partialSign(signers: []))
+    }
+}
+
+extension TransactionTests {
+
+    static func makeTransaction(
+        signer: Account,
+        feePayer: PublicKey = .StubFactory.make()
+    ) -> Transaction {
+        .init(
+            instructions: [
+                .init(
+                    keys: [
+                        .init(
+                            publicKey: signer.publicKey,
+                            isSigner: true,
+                            isWritable: true
+                        )
+                    ],
+                    programId: .fake,
+                    data: [UInt8]([0])
+                )
+            ],
+            recentBlockhash: "",
+            feePayer: feePayer
+        )
+    }
+}

--- a/Tests/SolanaSwiftUnitTests/TestDoubles/File.swift
+++ b/Tests/SolanaSwiftUnitTests/TestDoubles/File.swift
@@ -1,0 +1,19 @@
+//
+//  AccountStub.swift
+//  
+//
+//  Created by Kamil Wyszomierski on 21/06/2022.
+//
+
+import Foundation
+import SolanaSwift
+
+extension Account {
+
+    enum StubFactory {
+
+        static func make() -> Account {
+            try! .init(secretKey: .init([UInt8].StubFactory.make(length: 64)))
+        }
+    }
+}

--- a/Tests/SolanaSwiftUnitTests/TestDoubles/FixedWidthIntegerArrayStub.swift
+++ b/Tests/SolanaSwiftUnitTests/TestDoubles/FixedWidthIntegerArrayStub.swift
@@ -1,0 +1,18 @@
+//
+//  FixedWidthIntegerArrayStub.swift
+//  
+//
+//  Created by Kamil Wyszomierski on 21/06/2022.
+//
+
+import Foundation
+
+extension Array where Element: FixedWidthInteger {
+
+    enum StubFactory {
+
+        static func make(length: UInt, range: Range<Element> = Element.min..<Element.max) -> [Element] {
+            (0..<length).map { _ in .random(in: range) }
+        }
+    }
+}

--- a/Tests/SolanaSwiftUnitTests/TestDoubles/PublicKeyStub.swift
+++ b/Tests/SolanaSwiftUnitTests/TestDoubles/PublicKeyStub.swift
@@ -1,0 +1,19 @@
+//
+//  PublicKeyStub.swift
+//  
+//
+//  Created by Kamil Wyszomierski on 21/06/2022.
+//
+
+import Foundation
+import SolanaSwift
+
+extension PublicKey {
+
+    enum StubFactory {
+
+        static func make() -> PublicKey {
+            try! .init(bytes: .StubFactory.make(length: 32, range: 0..<UInt8.max))
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces public `partialSign`, in the same as [solana](https://github.com/solana-labs/solana-web3.js/) has.

Proposed change resolves a use case where developer uses external wallet app to sign a transaction and then continues with partial sign on returned transaction inside the app (eg. when creating user associated NFT).