### PR TITLE
Access to Signature constructor has been changed to public.

### DIFF
--- a/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
+++ b/Sources/SolanaSwift/Models/SendingTransaction/Transaction.swift
@@ -413,6 +413,11 @@ public extension Transaction {
         enum CodingKeys: String, CodingKey {
             case signature, publicKey
         }
+        
+        public init(signature: Data?, publicKey: PublicKey) {
+            self.signature = signature
+            self.publicKey = publicKey
+        }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)


### PR DESCRIPTION
In my case I need to create Signature outside the module.