### PR TITLE
Added `skipPreflight` to RequestConfiguration

### DIFF
--- a/Sources/SolanaSwift/Models/RequestModels.swift
+++ b/Sources/SolanaSwift/Models/RequestModels.swift
@@ -85,6 +85,7 @@ public struct RequestConfiguration: Encodable {
     public let limit: Int?
     public let before: String?
     public let until: String?
+    public let skipPreflight: Bool?
 
     public init?(
         commitment: Commitment? = nil,
@@ -93,13 +94,15 @@ public struct RequestConfiguration: Encodable {
         filters: [[String: EncodableWrapper]]? = nil,
         limit: Int? = nil,
         before: String? = nil,
-        until: String? = nil
+        until: String? = nil,
+        skipPreflight: Bool? = nil
     ) {
         if commitment == nil, encoding == nil, dataSlice == nil, filters == nil, limit == nil, before == nil,
-           until == nil
+           until == nil, skipPreflight == nil
         {
             return nil
         }
+        
         self.commitment = commitment
         self.encoding = encoding
         self.dataSlice = dataSlice
@@ -107,6 +110,7 @@ public struct RequestConfiguration: Encodable {
         self.limit = limit
         self.before = before
         self.until = until
+        self.skipPreflight = skipPreflight
     }
 }
 


### PR DESCRIPTION
As per Solana Documentation `skipPreflight` is optional and set to `false` by default. However in some cases you need the flag to be set to `true` for transactions to succeed.

This PR will not break any existing projects that are using this SDK since the property is optional and `nil` by default.