### PR TITLE
fix: add support for initializing this public struct

### DIFF
--- a/Sources/SolanaSwift/Models/RequestModels.swift
+++ b/Sources/SolanaSwift/Models/RequestModels.swift
@@ -117,4 +117,9 @@ public struct RequestConfiguration: Encodable {
 public struct DataSlice: Encodable {
     public let offset: Int
     public let length: Int
+    
+    public init(offset: Int, length: Int) {
+        self.offset = offset
+        self.length = length
+    }
 }


### PR DESCRIPTION
## Description

At the moment it seems to not be possible to use this struct from outside of the library, even tho its marked as public

```shell
'DataSlice' initializer is inaccessible due to 'internal' protection level
```