### PR TITLE
Add searchTransactionHistory parameter

### DIFF
--- a/Sources/SolanaSwift/Models/RequestModels.swift
+++ b/Sources/SolanaSwift/Models/RequestModels.swift
@@ -100,7 +100,7 @@ public struct RequestConfiguration: Encodable {
         preflightCommitment: Commitment? = nil
     ) {
         if commitment == nil, encoding == nil, dataSlice == nil, filters == nil, limit == nil, before == nil,
-           until == nil, skipPreflight == nil
+           until == nil, skipPreflight == nil, preflightCommitment == nil
         {
             return nil
         }

--- a/Sources/SolanaSwift/Models/RequestModels.swift
+++ b/Sources/SolanaSwift/Models/RequestModels.swift
@@ -87,6 +87,7 @@ public struct RequestConfiguration: Encodable {
     public let until: String?
     public let skipPreflight: Bool?
     public let preflightCommitment: Commitment?
+    public let searchTransactionHistory: Bool?
 
     public init?(
         commitment: Commitment? = nil,
@@ -97,10 +98,11 @@ public struct RequestConfiguration: Encodable {
         before: String? = nil,
         until: String? = nil,
         skipPreflight: Bool? = nil,
-        preflightCommitment: Commitment? = nil
+        preflightCommitment: Commitment? = nil,
+        searchTransactionHistory: Bool? = nil
     ) {
         if commitment == nil, encoding == nil, dataSlice == nil, filters == nil, limit == nil, before == nil,
-           until == nil, skipPreflight == nil, preflightCommitment == nil
+           until == nil, skipPreflight == nil, preflightCommitment == nil, searchTransactionHistory == nil
         {
             return nil
         }
@@ -114,6 +116,7 @@ public struct RequestConfiguration: Encodable {
         self.until = until
         self.skipPreflight = skipPreflight
         self.preflightCommitment = preflightCommitment
+        self.searchTransactionHistory = searchTransactionHistory
     }
 }
 


### PR DESCRIPTION
This parameter is needed to get the status of any "older" signatures not found in the recent status cache.

See Solana Documentation `searchTransactionHistory` for more details:
https://docs.solana.com/de/api/http#getsignaturestatuses

This PR will also correct the changes from the last commit "feat: preflightCommitment" (5a0feeb88f5607a936ba15a574ac6d911e377456):
The parameter preflightCommitment was added to RequestConfiguration, but the check,
if all parameters are nil were not updated for this new parameter.