### PR TITLE
[PublicKey] Fix `isOnCurve` index out of range crash, add `isOnCurve` helper

### DIFF
--- a/Sources/SolanaSwift/Models/PublicKey.swift
+++ b/Sources/SolanaSwift/Models/PublicKey.swift
@@ -50,6 +50,10 @@ public struct PublicKey: Codable, Equatable, CustomStringConvertible, Hashable {
     public var description: String {
         base58EncodedString
     }
+    
+    public var isOnCurve: Bool {
+        Self.isOnCurve(publicKey: base58EncodedString).toBool()
+    }
 
     public func short(numOfSymbolsRevealed: Int = 4) -> String {
         let pubkey = base58EncodedString
@@ -172,6 +176,10 @@ public extension PublicKey {
     }
 
     static func isOnCurve(publicKeyBytes: Data) -> Int {
+        guard !publicKeyBytes.bytes.isEmpty else {
+            return 0
+        }
+
         var r = [[Int64]](repeating: NaclLowLevel.gf(), count: 4)
 
         var t = NaclLowLevel.gf(),


### PR DESCRIPTION
# Context

If someone pass invalid public key string in the `isOnCurve(publicKey:)` function, `NaclLowLevel.unpack25519(_:_:)` will throw "index out of bounds" crash because of `publicKeyBytes.bytes` is empty.

# Details

- Added `publicKeyBytes.bytes.isEmpty` check.
- Added `isOnCurve` bool parameter for `PublicKey` structure.